### PR TITLE
Infer Offline and Multi Stream from Single Stream for Edge submissions

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -272,9 +272,9 @@ Each Edge benchmark *requires* the following scenarios, and sometimes permit an 
 For Edge submitters' convenience, they are allowed to obtain only a Single Stream result
 and have Offline and optionally Multi-Stream results inferred according to the following rules:
 
-- The corresponding Offline result can be _inferred_ as 1000 divided by the
-  Single Stream result (taken at the 90th percentile).  For example, a Single
-Stream result of 20 milliseconds per sample would imply an Offline result of 50
+- The corresponding Offline result can be _inferred_ as the Queries per Second reported
+in the Single Stream result, that is 1000 divided by the Mean latency.  For example, a Single
+Stream mean latency of 20 milliseconds would imply an Offline result of 50
 samples per second. The inferred Offline accuracy will be the same as the
 Single Stream accuracy.
 
@@ -286,9 +286,10 @@ Constraint of 50 milliseconds and 3 streams under the Latency Constraint of 66
 milliseconds. The inferred Multi-Stream accuracy will be the same as the Single
 Stream accuracy.
 
-To simplify automated processing of inferred results, the submitter must still
-create directory structures for the Offline scenario and, if to be submitted,
-for the Multi-Stream scenario, but leave them empty.
+To simplify automated processing of inferred results, the submitter should
+create copies of the correponding Single Stream directories under `results/`
+and `measurements/`, calling them `offline` for the Offline scenario and, if to
+be submitted, `multistream` for the Multi Stream scenario.
 
 Accuracy results must be reported to five significant figures with round to
 even. For example, 98.9995% should be recorded as 99.000%.

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -286,9 +286,9 @@ Constraint of 50 milliseconds and 3 streams under the Latency Constraint of 66
 milliseconds. The inferred Multi-Stream accuracy will be the same as the Single
 Stream accuracy.
 
-To simplify automated processing of inferred results, the submitter should still create
-directory structures for the Offline scenario and optionally for the Multi-Stream scenario,
-but leave them empty.
+To simplify automated processing of inferred results, the submitter must still
+create directory structures for the Offline scenario and, if to be submitted,
+for the Multi-Stream scenario, but leave them empty.
 
 Accuracy results must be reported to five significant figures with round to
 even. For example, 98.9995% should be recorded as 99.000%.

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -261,13 +261,34 @@ Each Edge benchmark *requires* the following scenarios, and sometimes permit an 
 
 |===
 |Area |Task |Required Scenarios |Optional Scenarios
-|Vision |Image classification |Single Stream, Offline |Multi-stream
-|Vision |Object detection (large) |Single Stream, Offline |Multi-stream
-|Vision |Object detection (small) |Single Stream, Offline |Multi-stream
+|Vision |Image classification |Single Stream, Offline |Multi-Stream
+|Vision |Object detection (large) |Single Stream, Offline |Multi-Stream
+|Vision |Object detection (small) |Single Stream, Offline |Multi-Stream
 |Vision |Medical image segmentation |Single Stream, Offline | N/A
 |Speech |Speech-to-text |Single Stream, Offline | N/A
 |Language |Language processing |Single Stream, Offline | N/A
 |===
+
+For Edge submitters' convenience, they are allowed to obtain only a Single Stream result
+and have Offline and optionally Multi-Stream results inferred according to the following rules:
+
+- The corresponding Offline result can be _inferred_ as 1000 divided by the
+  Single Stream result (taken at the 90th percentile).  For example, a Single
+Stream result of 20 milliseconds per sample would imply an Offline result of 50
+samples per second. The inferred Offline accuracy will be the same as the
+Single Stream accuracy.
+
+- The corresponding Multi-Stream result can be _inferred_ as the Latency
+  Constraint divided by the Single Stream result (taken at the 99th percentile)
+and rounded down.  For example, a Single Stream result of 20 milliseconds per
+sample would imply a Multi Stream result of 2 streams under the Latency
+Constraint of 50 milliseconds and 3 streams under the Latency Constraint of 66
+milliseconds. The inferred Multi-Stream accuracy will be the same as the Single
+Stream accuracy.
+
+To simplify automated processing of inferred results, the submitter should still create
+directory structures for the Offline scenario and optionally for the Multi-Stream scenario,
+but leave them empty.
 
 Accuracy results must be reported to five significant figures with round to
 even. For example, 98.9995% should be recorded as 99.000%.


### PR DESCRIPTION
As we discussed in the Submitters' WG on 1/Sep/2020.

I've added a paragraph on creating empty directory structures for inferred results. This is one way to ensure that the submitter makes a conscious decision to have the results inferred in this way. This is especially true for the Multi Stream result, as this scenario may not make a great deal of sense for the submitter to present. Please feel free to propose any other ideas how to deal with this situation.

We will try to check how this might affect the submission checker by the next WG meeting on 8/Sep/2020.