### PR TITLE
Increase duration to 10 minutes

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -140,8 +140,8 @@ described in the table below.
 
 |===
 |Scenario |Query Generation |Duration |Samples/query |Latency Constraint |Tail Latency | Performance Metric
-|Single stream |LoadGen sends next query as soon as SUT completes the previous query | 1024 queries and 60 seconds |1 |None |90% | 90%-ile measured latency
-|Multiple stream |LoadGen sends a new query every _latency constraint_ if the SUT has completed the prior query, otherwise the new query is dropped and is counted as one overtime query | 270,336 queries and 60 seconds |Variable, see metric |Benchmark specific |99% | Maximum number of inferences per query supported
+|Single stream |LoadGen sends next query as soon as SUT completes the previous query | 1024 queries and 600 seconds |1 |None |90% | 90%-ile measured latency
+|Multiple stream |LoadGen sends a new query every _latency constraint_ if the SUT has completed the prior query, otherwise the new query is dropped and is counted as one overtime query | 270,336 queries and 600 seconds |Variable, see metric |Benchmark specific |99% | Maximum number of inferences per query supported
 |Server |LoadGen sends new queries to the SUT according to a Poisson distribution |270,336 queries and 600 seconds |1 |Benchmark specific |99% | Maximum Poisson throughput parameter supported
 |Offline |LoadGen sends all queries to the SUT at start | 1 query and 600 seconds | At least 24,576 |None |N/A | Measured throughput
 |===

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -142,8 +142,8 @@ described in the table below.
 |Scenario |Query Generation |Duration |Samples/query |Latency Constraint |Tail Latency | Performance Metric
 |Single stream |LoadGen sends next query as soon as SUT completes the previous query | 1024 queries and 60 seconds |1 |None |90% | 90%-ile measured latency
 |Multiple stream |LoadGen sends a new query every _latency constraint_ if the SUT has completed the prior query, otherwise the new query is dropped and is counted as one overtime query | 270,336 queries and 60 seconds |Variable, see metric |Benchmark specific |99% | Maximum number of inferences per query supported
-|Server |LoadGen sends new queries to the SUT according to a Poisson distribution |270,336 queries and 60 seconds |1 |Benchmark specific |99% | Maximum Poisson throughput parameter supported
-|Offline |LoadGen sends all queries to the SUT at start | 1 query and 60 seconds | At least 24,576 |None |N/A | Measured throughput
+|Server |LoadGen sends new queries to the SUT according to a Poisson distribution |270,336 queries and 600 seconds |1 |Benchmark specific |99% | Maximum Poisson throughput parameter supported
+|Offline |LoadGen sends all queries to the SUT at start | 1 query and 600 seconds | At least 24,576 |None |N/A | Measured throughput
 |===
 
 The number of queries is selected to ensure sufficient statistical confidence in


### PR DESCRIPTION
Based on internal Google experiments, one minute is not sufficient to capture steady-state performance for many datacenter ML accelerators. A ten minute run is more reflective of long-term performance. This proposed change only affects the Offline and Server scenarios. Single-stream and Multi-stream retain a one minute minimum duration.