### PR TITLE
Update policy on caching

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -379,7 +379,7 @@ The execution of LoadGen is restricted as follows:
   show how the input activation bandwidth utilized by each benchmark/scenario combination can be delivered from the 
   network or I/O device to that memory
 
-* Caching of any queries, any query parameters, or any intermediate results is
+* Caching values derived from the shapes of input tensors is allowed. Caching of any other queries, query parameters, or intermediate results is
   prohibited.
 
 * The LoadGen must be compiled from a tagged approved revision of the mlperf/inference

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -380,7 +380,7 @@ The execution of LoadGen is restricted as follows:
   network or I/O device to that memory
 
 * Caching values derived from the shapes of input tensors is allowed. Caching of any other queries, query parameters, or intermediate results is
-  prohibited.
+  prohibited. In particular, caching values derived from activations is prohibited.
 
 * The LoadGen must be compiled from a tagged approved revision of the mlperf/inference
   GitHub repository without alteration.  Pull requests addressing portability


### PR DESCRIPTION
The caching rules are too strict. 

Consider a routine where there is some configuration state based on the shape of the input tensors to the network. MLPerf allows you to:

* instance the routine and inline every combination of shapes that will be seen in the validation set
* precompute the configuration state for every combination of shapes seen in the validation set

But it does not allow you to do that computation on the fly and maintain a cache of recently seen configurations, even though the latter is very likely the strategy used in production.