### PR TITLE
Remove section on availability

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -69,16 +69,6 @@ as fairly as possible. Ethics and reputation matter.
 The same system and framework must be used for a suite result or set of
 benchmark results reported in a single context.
 
-=== System and framework must be available
-
-If you are measuring the performance of a publicly available and widely-used
-system or framework, you must use publicly available and widely-used versions of
-the system or framework.
-
-If you are measuring the performance of an experimental framework or system, you
-must make the system and framework you use available upon demand for
-replication.
-
 === Benchmark implementations must be shared
 
 Source code used for the benchmark implementations must be open-sourced under a


### PR DESCRIPTION
This section contains a definition of availability that is at odds with the definition in the main policies document, and is causing confusion, see https://github.com/mlcommons/inference_results_v0.7/issues/15. It also contains a statement about making experimental systems available for replication which is inconsistent with current practice, where you only need to make the system available if audited - this being covered by the audit rules.