### PR TITLE
Get rid of "Not supported" for server

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -296,8 +296,6 @@ create copies of the correponding Single Stream directories under `results/`
 and `measurements/`, calling them `offline` for the Offline scenario and, if to
 be submitted, `multistream` for the Multi-Stream scenario.
 
-If a system does not achieve the required Server target tail latency for a model required by a suite then its Server performance will be recorded as "Not Supported" in the results table.
-
 Accuracy results must be reported to five significant figures with round to
 even. For example, 98.9995% should be recorded as 99.000%.
 


### PR DESCRIPTION
"Does not meet the latency target" was controversial in review; I believe the consensus was that we should get rid of this.