### PR TITLE
Update inference_rules.adoc

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -164,8 +164,7 @@ Each sample has the following definition:
 |===
 |Model| definition of one sample
 |Resnet50-v1.5	    |one image
-|SSD-ResNet34	    |one image
-|SSD-MobileNet-v1   | one image
+|SSD-ResNeXt50	    |one image
 |3D UNET	        |one image
 |RNNT	            |one raw speech sample up to 15 seconds
 |BERT	            |one sequence
@@ -240,7 +239,7 @@ The Datacenter suite includes the following benchmarks:
 |===
 |Area |Task |Model |Dataset |QSL Size |Quality |Server latency constraint
 |Vision |Image classification |Resnet50-v1.5 |ImageNet (224x224) | 1024 | 99% of FP32 (76.46%) | 15 ms
-|Vision |Object detection (large) |SSD-ResNet34 |COCO (1200x1200) | 64 | 99% of FP32 (0.20 mAP) | 100 ms
+|Vision |Object detection |SSD-ResNexT50 |OpenImages (800x800) | 64 | 99% of FP32 (0.375 mAP) | 100 ms
 |Vision |Medical image segmentation |3D UNET |KiTS 2019 | 42 | 99% of FP32 and 99.9% of FP32 (0.86330 mean DICE score) | N/A
 |Speech |Speech-to-text |RNNT |Librispeech dev-clean (samples < 15 seconds) | 2513 | 99% of FP32 (1 - WER, where WER=7.452253714852645%) | 1000 ms
 |Language |Language processing |BERT |SQuAD v1.1 (max_seq_len=384) | 10833 | 99% of FP32 and 99.9% of FP32 (f1_score=90.874%) | 130 ms
@@ -252,7 +251,7 @@ Each Datacenter benchmark *requires* the following scenarios:
 |===
 |Area |Task |Required Scenarios 
 |Vision |Image classification |Server, Offline
-|Vision |Object detection (large) |Server, Offline
+|Vision |Object detection |Server, Offline
 |Vision |Medical image segmentation |Offline
 |Speech |Speech-to-text |Server, Offline
 |Language |Language processing |Server, Offline
@@ -264,8 +263,7 @@ The Edge suite includes the following benchmarks:
 |===
 |Area |Task |Model |Dataset |QSL Size |Quality
 |Vision |Image classification |Resnet50-v1.5 |ImageNet (224x224) | 1024 | 99% of FP32 (76.46%)
-|Vision |Object detection (large) |SSD-ResNet34 |COCO (1200x1200) | 64 | 99% of FP32 (0.20 mAP)
-|Vision |Object detection (small) |SSD-MobileNets-v1 |COCO (300x300) | 256 | 99% of FP32 (0.22 mAP)
+|Vision |Object detection |SSD-ResNeXt50 |OpenImages (800x800) | 64 | 99% of FP32 (0.375 mAP)
 |Vision |Medical image segmentation |3D UNET |KiTS 2019 | 42 | 99% of FP32 and 99.9% of FP32 (0.86330 mean DICE score)
 |Speech |Speech-to-text |RNNT |Librispeech dev-clean (samples < 15 seconds)| 2513 | 99% of FP32 (1 - WER, where WER=7.452253714852645%)
 |Language |Language processing |BERT |SQuAD v1.1 (max_seq_len=384) | 10833 | 99% of FP32 (f1_score=90.874%)
@@ -276,8 +274,7 @@ Each Edge benchmark *requires* the following scenarios, and sometimes permit an 
 |===
 |Area |Task |Required Scenarios
 |Vision |Image classification |Single Stream, Multistream, Offline
-|Vision |Object detection (large) |Single Stream, Multistream, Offline
-|Vision |Object detection (small) |Single Stream, Multistream, Offline
+|Vision |Object detection |Single Stream, Multistream, Offline
 |Vision |Medical image segmentation |Single Stream, Offline
 |Speech |Speech-to-text |Single Stream, Offline
 |Language |Language processing |Single Stream, Offline
@@ -895,7 +892,7 @@ Datacenter systems must provide at least the following bandwidths from the netwo
 |===
 |Area |Model |Dataset | Symbolic input size formula | Numeric input size formula | Minimum network bandwidth (bytes/sec)
 |Vision |Resnet50-v1.5 |ImageNet (224x224) | __C*H*W*dtype_size__ | __3*224*224*dtype_size__ | __throughput*150528*dtype_size
-__|Vision |SSD-ResNet34 |COCO (1200x1200) | __C*H*W*dtype_size__ | __3*1200*1200*dtype_size__ | __throughput*4320000*dtype_size__
+__|Vision |SSD-ResNeXt50 |OpenImages (800x800) | __C*H*W*dtype_size__ | __3*800*800*dtype_size__ | __throughput*1920000*dtype_size__
 |Vision |3D UNET | KiTS 2019 | __avg(C*D*H*W)*dtype_size__footnote:3d_unet_bw[The average image size above is the average image size of the inference cases specified in https://github.com/mlcommons/inference/blob/master/vision/medical_imaging/3d-unet-kits19/meta/inference_cases.json[inference_cases.json].] | __32381026*dtype_size__ | __throughput*32381026*dtype_size__
 |Speech |RNNT |Librispeech dev-clean (samples < 15 seconds) | __max_audio_duration*num_samples_per_sec*(bits_per_sample/8)__ | __15*16000*(16/8)__ | __throughput*480000__
 |Language |BERT |SQuAD v1.1 (max_seq_len=384) | __num_inputs*max_seq_len*dtype_size__ | __3*384*dtype_size__ | __throughput*1152*dtype_size__
@@ -909,7 +906,7 @@ Datacenter systems must provide at least the following bandwidths from the outpu
 |===
 |Area |Model |Dataset | Symbolic input size formula | Numeric input size formula | Minimum network bandwidth (bytes/sec)
 |Vision |Resnet50-v1.5 |ImageNet (224x224) | negligible | negligible | __> 0
-__|Vision |SSD-ResNet34 |COCO (1200x1200) | negligible | negligible | __> 0__
+__|Vision |SSD-ResNeXt50 |OpenImages (800x800) | negligible | negligible | __> 0__
 |Vision |3D UNET | KiTS 2019 | __avg(C*D*H*W)*dtype_size__footnote:3d_unet_bw[] | __32381026*dtype_size__ | __throughput*32381026*dtype_size__
 |Speech |RNNT |Librispeech dev-clean (samples < 15 seconds) | negligible | negligible | __> 0__
 |Language |BERT |SQuAD v1.1 (max_seq_len=384) | negligible | negligible | __> 0__


### PR DESCRIPTION
Update all object detection references to SSD-ResNeXt50 (effective v2.1 inference). Essentially replacing SSD-ResNet34 and SSD-MobileNet with SSD-ResNeXt50