### PR TITLE
Random seeds to be released four weeks before

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -89,7 +89,7 @@ The only forms of acceptable non-determinism are:
 All random numbers must be based on fixed random seeds and a deterministic random
 number generator. The deterministic random number generator is the Mersenne Twister
 19937 generator ([std::mt19937](http://www.cplusplus.com/reference/random/mt19937/)).
-The random seeds will be announced two weeks before the benchmark submission deadline.
+The random seeds will be announced four weeks before the benchmark submission deadline.
 
 === Benchmark detection is not allowed
 


### PR DESCRIPTION
As discussed in 10/25/2022 Inference WG meeting, changing the rules to allow random seeds to be release 4 weeks in advance.