### PR TITLE
Rules update for auditor selection timeline

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -106,7 +106,7 @@ The process of random selection is in two stages: first a submitter is randomly 
 
 The review committee will select a submission for audit by ranked choice voting. One option shall be "No Selected Audit This Round".
 
-An auditor shall be chosen by the review committee who has no conflict of interest with the submitter. The process of auditor selection can take no longer than 4 weeks from selection of the submitter.
+An auditor shall be chosen by the review committee who has no conflict of interest with the submitter. The process of auditor selection can take no longer than 28 days from selection of the submitter.
 
 The burden is on the submitter to provide sufficient materials to demonstrate that the submission is compliant with the rules. Any such materials, including software, documentation, testing results and machine access will be provided to the auditor under NDA.
 

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -106,7 +106,7 @@ The process of random selection is in two stages: first a submitter is randomly 
 
 The review committee will select a submission for audit by ranked choice voting. One option shall be "No Selected Audit This Round".
 
-An auditor shall be chosen by the review committee who has no conflict of interest with the submitter. The process of auditor selection can take no longer than 28 days from selection of the submitter.
+An auditor shall be chosen by the review committee who has no conflict of interest with the submitter. The process of auditor selection will take no more than 28 days from selection of the submitter.
 
 The burden is on the submitter to provide sufficient materials to demonstrate that the submission is compliant with the rules. Any such materials, including software, documentation, testing results and machine access will be provided to the auditor under NDA.
 
@@ -123,6 +123,7 @@ If a submission failed an audit that was delayed past publication, then any publ
 
 MLCommons shall retain a library of past audit reports and send copies to MLCommons members, auditors, and potential auditors by request. Audit reports will not be further distributed without permission from the audited submitter.
 
+An audit is expected to be completed within a 90 day period. Audits failing to meet this timeline will be nullified by request of the auditee.
 == Scenarios
 
 In order to enable representative testing of a wide variety of inference

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -123,7 +123,8 @@ If a submission failed an audit that was delayed past publication, then any publ
 
 MLCommons shall retain a library of past audit reports and send copies to MLCommons members, auditors, and potential auditors by request. Audit reports will not be further distributed without permission from the audited submitter.
 
-An audit is expected to be completed within a 90 day period. Audits failing to meet this timeline will be nullified by request of the auditee.
+An audit is expected to be completed within a 90 day period. Audits failing to meet this timeline can be requested to be invalidated by the auditee. The final decision to accept such a request will be determined by the Working Group.
+
 == Scenarios
 
 In order to enable representative testing of a wide variety of inference

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -106,7 +106,7 @@ The process of random selection is in two stages: first a submitter is randomly 
 
 The review committee will select a submission for audit by ranked choice voting. One option shall be "No Selected Audit This Round".
 
-An auditor shall be chosen by the review committee who has no conflict of interest with the submitter.
+An auditor shall be chosen by the review committee who has no conflict of interest with the submitter. The process of auditor selection can take no longer than 4 weeks from selection of the submitter.
 
 The burden is on the submitter to provide sufficient materials to demonstrate that the submission is compliant with the rules. Any such materials, including software, documentation, testing results and machine access will be provided to the auditor under NDA.
 

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -123,7 +123,7 @@ If a submission failed an audit that was delayed past publication, then any publ
 
 MLCommons shall retain a library of past audit reports and send copies to MLCommons members, auditors, and potential auditors by request. Audit reports will not be further distributed without permission from the audited submitter.
 
-An audit is expected to be completed within a 90 day period. Audits failing to meet this timeline can be requested to be invalidated by the auditee. The final decision to accept such a request will be determined by the Working Group.
+An audit is expected to be completed within a 90 day period. Audits failing to meet this timeline can be requested to be invalidated by the auditee. The final decision to accept such a request will be taken by the Working Group.
 
 == Scenarios
 


### PR DESCRIPTION
As discussed in the working group on 2/28. Updating the rules to restrict the time for auditor selection.