### PR TITLE
Rules clarification to prevent sorting beyond datset boundaries in LLMs

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -147,7 +147,8 @@ described in the table below.
 
 An early stopping criterion (described in more detail in <<appendix-early_stopping>>) allows for runs with a relatively small number of processed queries to be valid, with the penalty that the effective computed percentile will be slightly higher.  This penalty counteracts the increased variance inherent to runs with few queries, where there is a higher probability that a particular run will, by chance, report a lower latency than the system should reliably support.
 
-In the above table, tail latency percentiles with an asterisk represent the theoretical lower limit of measured percentile for runs processing a very large number of queries.  Submitters may opt to run for longer than the time listed in the "Duration" column, in order to decrease the effect of the early stopping penalty.  See the following table for a suggested starting point for how to set the minimum number of queries.
+In the above table, tail latency percentiles with an asterisk represent the theoretical lower limit of measured percentile for runs processing a very large number of queries.  Submitters may opt to run for longer than the time listed in the "Duration" column, in order to decrease the effect of the early stopping penalty. If submitters opt to run for a longer "duration" or exceed the minium number of "samples/query" in the Offline scenario, such that it requires multiple copies of the test dataset, submitters are `NOT` allowed to sort samples beyond the boundary of a dataset. 
+See the following table for a suggested starting point for how to set the minimum number of queries.
 
 |===
 |Tail Latency Percentile |Confidence Interval |Margin-of-Error |Inferences |Rounded Inferences
@@ -776,6 +777,8 @@ The following techniques are disallowed:
 * Techniques that only improve performance when there are identical
   samples in a query. For example, sorting samples in SSD and R-GAT.
 
+* Techniques that only improve performance by artificially creating batches of identical samples. For example, sorting samples beyond the boundary of a dataset when exceeding the minimum number of queries or minimum time duration in a valid test run in GPT-J, Llama2-70b, Llama2-70b-Interactive, Llama3.1-405B, and Mixtral-8x7B. 
+
 * Speculative decoding for auto-generative language models (i.e. using a smaller model to predict the next token for the reference model).
 
 == FAQ
@@ -809,7 +812,7 @@ routine/scripts.
 
 Q: Is it permissible to exceed both the minimum number of queries and minimum time duration in a valid test run?
 
-A: Yes.
+A: Yes.However, if exceeding the minimum number of queries or minimum time duration requires loading multiple copies of the dataset, submitters are not allowed to sort samples beyond the boundary of a dataset.
 
 Q: Can we give the driver a hint to preload the image data to somewhere closer to the accelerator?
 


### PR DESCRIPTION
This PR addresses and clarifies the rules for dataset sorting in LLM benchmarks, specifically focusing on the offline scenario. The changes aim to ensure fair and consistent performance evaluation across submissions.

Proposed changes for LLM benchmarks-
1. **Dataset Sorting Limitation**: Sorting is restricted to within the boundaries of a single dataset copy. This prevents the creation of batches with identical queries from multiple dataset copies, which could lead to artificial performance advantages.
2. **Clarification on Runtime:** Submitters are still allowed to run beyond the minimum duration time, and sorting of queries within a  dataset copy is permitted.
3. **Addressing Performance Bias**: The new rule eliminates the potential unfair advantage gained from batching identical queries with identical sequence lengths across multiple dataset copies. The refined rules better reflect real-world scenarios, where identical queries are not typically grouped together

