### PR TITLE
v5.0 Inference post-mortem item - Enforcing rules on late submissions

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -129,6 +129,17 @@ MLCommons shall retain a library of past audit reports and send copies to MLComm
 
 An audit is expected to be completed within a 90 day period. Audits failing to meet this timeline can be requested to be invalidated by the auditee. The final decision to accept such a request will be taken by the Working Group.
 
+=== Late Submissions and Late Upload of Logs
+
+To ensure fairness to all submitters and the integrity of the process, MLPerf Inference will strictly adhere to the https://github.com/mlcommons/policies/blob/master/submission_rules.adoc#late-submissions[MLCommons general submission rules]. The 60 minute grace period will be strictly enforced, and any late submissions will not be considered as valid submissions. Exceptions will be made only in extraordinary circumstances as listed in the https://github.com/mlcommons/policies/blob/master/submission_rules.adoc#532-post-submission-extension-for-extraordinary-circumstances-submission-deadline--72-hours[mlcommons guidelines.]
+
+Once the submission deadline has passed, the submission round is considered to be under review. Submitters may not submit new accuracy, performance, or power logs during the review process. Exceptions may only be made at the discretion of the Review Committee to ensure compliance with the rules. For example, if logs are corrupted during the submission process or if the submission checker fails to identify missing logs, the Review Committee may choose to allow the logs to be reuploaded. 
+
+Under no circumstance will submitters be allowed to upload new logs that alter the accuracy, performance, or power results, irrespective of the magnitude of change. 
+
+Submitters will be allowed to correct or add missing missing documentation, configs, system jsons, and other descriptors to ensure compliance and correctness, as identified during the review process. 
+
+
 == Scenarios
 
 In order to enable representative testing of a wide variety of inference


### PR DESCRIPTION
This PR addresses issues that arose in the v5.0 and prior inference reviews and attempts to clarify the rules surrounding late submissions. 

This PR:

1. Reinforces the mlcommon rules and asks that the 60 min grace period be strictly adhered to. 
2. Explicitly lists out the only circumstances in which late submissions will be accepted.
3. Explicitly prohibits any new logs that will change performance/power/accuracy.

The goal is:
1. Help streamline the review process - we spend far too much time on late submissions. 
2. Enforce fairness and ensure all submitters get equal time. 
3. Addresses the consideration that unforced errors can happen during the submission process.