### PR TITLE
feat(edge-agentic): add BFCL v4 edge-agentic workload to edge benchma…

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -305,7 +305,7 @@ The Edge suite includes the following benchmarks:
 |Language |Summarization |Llama3.1-8B |CNN Dailymail (v3.0.0, max_seq_len=2048) | 5000 | 99% of FP32 and 99.9% of FP32 (rouge1=42.9865, rouge2=20.1235, rougeL=29.9881). Additionally, for both cases the total generation length of the texts should be more than 90% of the reference (gen_len=8167644)
 |Language |Language processing |BERT |SQuAD v1.1 (max_seq_len=384) | 10833 | 99% of FP32 and 99.9% of FP32(f1_score=90.874%)
 |Automotive | 3D Object Detection | PointPainting | Waymo Open Dataset | 1024 | 99.9% of FP32 (0.5425 mAP)
-|Audio |Speech to Text |Whisper |LibriSpeech | 1633 |99% of FP32 and 99.9% of FP32 (WER=2.0671%) | N/A
+|Audio |Speech to Text |Whisper |LibriSpeech | 1633 |99% of FP32 and 99.9% of FP32 (WER=2.0671%) 
 |Language |Agentic Function Calling |Qwen3.6-27B |gorilla-llm/gorilla-eval-set (BFCL v4; non_live 20%, live 10%, hallucination 5%, multi-turn 3%) | TBD | 99% of reference (single-turn overall=87.50%, multi-turn overall=TBD)
 |===
 [[edge-required-scenarios]]

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -306,7 +306,7 @@ The Edge suite includes the following benchmarks:
 |Language |Language processing |BERT |SQuAD v1.1 (max_seq_len=384) | 10833 | 99% of FP32 and 99.9% of FP32(f1_score=90.874%)
 |Automotive | 3D Object Detection | PointPainting | Waymo Open Dataset | 1024 | 99.9% of FP32 (0.5425 mAP)
 |Audio |Speech to Text |Whisper |LibriSpeech | 1633 |99% of FP32 and 99.9% of FP32 (WER=2.0671%) 
-|Language |Agentic Function Calling |Qwen3.6-27B |gorilla-llm/gorilla-eval-set (BFCL v4; non_live 20%, live 10%, hallucination 5%, multi-turn 3%) | TBD | 99% of reference (single-turn overall=87.50%, multi-turn overall=TBD)
+|Language |Agentic Function Calling |Qwen3.6-27B |gorilla-llm/gorilla-eval-set (BFCL v4; non_live 20%, live 10%, hallucination 5%, multi-turn 3%) | TBD | 99% of reference (single-turn overall=87.50% → threshold 86.63%, multi-turn overall=45.84% → threshold 45.38%)
 |===
 [[edge-required-scenarios]]
 Each Edge benchmark *requires* the following scenarios, and sometimes permit an optional scenario:

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -306,7 +306,7 @@ The Edge suite includes the following benchmarks:
 |Language |Language processing |BERT |SQuAD v1.1 (max_seq_len=384) | 10833 | 99% of FP32 and 99.9% of FP32(f1_score=90.874%)
 |Automotive | 3D Object Detection | PointPainting | Waymo Open Dataset | 1024 | 99.9% of FP32 (0.5425 mAP)
 |Audio |Speech to Text |Whisper |LibriSpeech | 1633 |99% of FP32 and 99.9% of FP32 (WER=2.0671%) 
-|Language |Agentic Function Calling |Qwen3.6-27B |gorilla-llm/gorilla-eval-set (BFCL v4; non_live 20%, live 10%, hallucination 5%, multi-turn 3%) | 480 | 99% of reference (single-turn overall=87.50% → threshold 86.63%, multi-turn overall=45.84% → threshold 45.38%)
+|Language |Agentic Function Calling |Qwen3.6-27B |gorilla-llm/gorilla-eval-set (BFCL v4 single-turn: non_live, live, hallucination) | 995 | 97% of validated Q4_K_M reference, 3% one-sided band (single-turn overall=86.23% → threshold 83.64%, non_live-normalized=87.96% → threshold 85.32%)
 |===
 [[edge-required-scenarios]]
 Each Edge benchmark *requires* the following scenarios, and sometimes permit an optional scenario:

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -275,6 +275,7 @@ The Datacenter suite includes the following benchmarks:
 |Generative |Text to video |WAN-2.2-T2V-A14B |VBench prompts | 248 |99% of BF16 (VBench score >= 69.7752) | N/A
 |Graph |Node classification |RGAT |IGBH | 788379 |99% of FP32 (72.86%) | N/A
 |Audio |Speech to Text |Whisper |LibriSpeech | 1633 |99% of FP32 and 99.9% of FP32 (WER=2.0671%) | N/A
+|Language |Agentic Function Calling |Qwen3.6-27B |gorilla-llm/gorilla-eval-set (BFCL v4; non_live 20%, live 10%, hallucination 5%, multi-turn 3%) | TBD | 99% of reference (single-turn overall=87.50%, multi-turn overall=TBD)
 |===
 [[dc-required-scenarios]]
 Each Datacenter benchmark *requires* the following scenarios:

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -306,7 +306,7 @@ The Edge suite includes the following benchmarks:
 |Language |Language processing |BERT |SQuAD v1.1 (max_seq_len=384) | 10833 | 99% of FP32 and 99.9% of FP32(f1_score=90.874%)
 |Automotive | 3D Object Detection | PointPainting | Waymo Open Dataset | 1024 | 99.9% of FP32 (0.5425 mAP)
 |Audio |Speech to Text |Whisper |LibriSpeech | 1633 |99% of FP32 and 99.9% of FP32 (WER=2.0671%) 
-|Language |Agentic Function Calling |Qwen3.6-27B |gorilla-llm/gorilla-eval-set (BFCL v4; non_live 20%, live 10%, hallucination 5%, multi-turn 3%) | TBD | 99% of reference (single-turn overall=87.50% → threshold 86.63%, multi-turn overall=45.84% → threshold 45.38%)
+|Language |Agentic Function Calling |Qwen3.6-27B |gorilla-llm/gorilla-eval-set (BFCL v4; non_live 20%, live 10%, hallucination 5%, multi-turn 3%) | 480 | 99% of reference (single-turn overall=87.50% → threshold 86.63%, multi-turn overall=45.84% → threshold 45.38%)
 |===
 [[edge-required-scenarios]]
 Each Edge benchmark *requires* the following scenarios, and sometimes permit an optional scenario:

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -275,7 +275,6 @@ The Datacenter suite includes the following benchmarks:
 |Generative |Text to video |WAN-2.2-T2V-A14B |VBench prompts | 248 |99% of BF16 (VBench score >= 69.7752) | N/A
 |Graph |Node classification |RGAT |IGBH | 788379 |99% of FP32 (72.86%) | N/A
 |Audio |Speech to Text |Whisper |LibriSpeech | 1633 |99% of FP32 and 99.9% of FP32 (WER=2.0671%) | N/A
-|Language |Agentic Function Calling |Qwen3.6-27B |gorilla-llm/gorilla-eval-set (BFCL v4; non_live 20%, live 10%, hallucination 5%, multi-turn 3%) | TBD | 99% of reference (single-turn overall=87.50%, multi-turn overall=TBD)
 |===
 [[dc-required-scenarios]]
 Each Datacenter benchmark *requires* the following scenarios:
@@ -307,10 +306,10 @@ The Edge suite includes the following benchmarks:
 |Language |Language processing |BERT |SQuAD v1.1 (max_seq_len=384) | 10833 | 99% of FP32 and 99.9% of FP32(f1_score=90.874%)
 |Automotive | 3D Object Detection | PointPainting | Waymo Open Dataset | 1024 | 99.9% of FP32 (0.5425 mAP)
 |Audio |Speech to Text |Whisper |LibriSpeech | 1633 |99% of FP32 and 99.9% of FP32 (WER=2.0671%) | N/A
+|Language |Agentic Function Calling |Qwen3.6-27B |gorilla-llm/gorilla-eval-set (BFCL v4; non_live 20%, live 10%, hallucination 5%, multi-turn 3%) | TBD | 99% of reference (single-turn overall=87.50%, multi-turn overall=TBD)
 |===
 [[edge-required-scenarios]]
 Each Edge benchmark *requires* the following scenarios, and sometimes permit an optional scenario:
-
 |===
 |Area |Task |Required Scenarios
 |Vision |Image classification |Single Stream, Multistream, Offline
@@ -320,6 +319,7 @@ Each Edge benchmark *requires* the following scenarios, and sometimes permit an 
 |Language |Summarization |Single Stream, Offline
 |Automotive | 3D object detection | Single Stream with 99.9% tail latency
 |Audio |Speech to Text | Offline
+|Language |Agentic Function Calling | Offline (accuracy-only)
 |===
 
 


### PR DESCRIPTION
## Summary

Adds the Edge Agentic workload (BFCL v4 function-calling accuracy) to the
MLPerf Inference edge benchmarks and required-scenarios tables.

## Changes

- Edge benchmarks table: new row — Language | Agentic Function Calling | Qwen3.6-27B | gorilla-llm/gorilla-eval-set (BFCL v4 single-turn: non_live, live, hallucination) | QSL 995 | 97% of validated Q4_K_M reference, 3% one-sided band (single-turn overall=86.23% → threshold 83.64%, non_live-normalized=87.96% → threshold 85.32%)
- Edge required-scenarios table: new row — Language | Agentic Function Calling | Offline (accuracy-only)

## Related

- Reference implementation: mlcommons/endpoints#346
- Inference catalog entry: mlcommons/inference language/edge-agentic
